### PR TITLE
Fix include paths

### DIFF
--- a/src/HOM/Makefile
+++ b/src/HOM/Makefile
@@ -6,21 +6,20 @@ include ../CustomGLTF.global
 DSONAME = $(HOM_LIB).$(EXT)
 
 # Custom GLTF library
-GHEADER = "../GLTF"
-GLIB = "../GLTF"
+CUSTOM_GLTF = ".."
 
 SOURCES = HOM_GLTF.C
 
 INCDIRS = \
-	-I$(GHEADER) \
+	-I$(CUSTOM_GLTF) \
 	-I$(HFS)/toolkit/include \
     -I$(HFS)/python27/include
 
 ifdef WINDOWS
-LIBDIRS += -LIBPATH:$(GLIB) -LIBPATH:$(HFS)/python27/libs
+LIBDIRS += -LIBPATH:$(CUSTOM_GLTF)/GLTF -LIBPATH:$(HFS)/python27/libs
 LIBS += lib$(GLTFLIB).lib
 else
-LIBDIRS += -L$(GLIB) -L$(HFS)/python27/libs
+LIBDIRS += -L$(CUSTOM_GLTF)/GLTF -L$(HFS)/python27/libs
 LIBS += -l$(GLTFLIB)
 endif
 

--- a/src/ROP/Makefile
+++ b/src/ROP/Makefile
@@ -6,8 +6,7 @@ include ../CustomGLTF.global
 DSONAME = $(ROPLIB).$(EXT)
 
 # Custom GLTF library
-GHEADER = "../GLTF"
-GLIB = "../GLTF"
+CUSTOM_GLTF = ".."
 
 SOURCES = \
 	ROP_GLTF.C \
@@ -16,14 +15,14 @@ SOURCES = \
     ROP_GLTF_Refiner.C
 
 INCDIRS = \
-    -I$(GHEADER) \
+    -I$(CUSTOM_GLTF) \
     -I$(HFS)/toolkit/include
 
 ifdef WINDOWS
-LIBDIRS += -LIBPATH:$(GLIB)
+LIBDIRS += -LIBPATH:$(CUSTOM_GLTF)/GLTF
 LIBS += lib$(GLTFLIB).lib
 else
-LIBDIRS += -L$(GLIB)
+LIBDIRS += -L$(CUSTOM_GLTF)/GLTF
 LIBS += -l$(GLTFLIB)
 endif
 

--- a/src/SOP/Makefile
+++ b/src/SOP/Makefile
@@ -6,20 +6,19 @@ include ../CustomGLTF.global
 DSONAME = $(SOPLIB).$(EXT)
 
 # Custom GLTF library
-GHEADER = "../GLTF"
-GLIB = "../GLTF"
+CUSTOM_GLTF = ".."
 
 SOURCES = SOP_GLTF.C
 
 INCDIRS = \
-    -I$(GHEADER) \
+    -I$(CUSTOM_GLTF) \
     -I$(HFS)/toolkit/include
 
 ifdef WINDOWS
-LIBDIRS += -LIBPATH:$(GLIB)
+LIBDIRS += -LIBPATH:$(CUSTOM_GLTF)/GLTF
 LIBS += lib$(GLTFLIB).lib
 else
-LIBDIRS += -L$(GLIB)
+LIBDIRS += -L$(CUSTOM_GLTF)/GLTF
 LIBS += -l$(GLTFLIB)
 endif
 


### PR DESCRIPTION
Right now GLTF headers are included from Houdini instead of the custom GLTF folder, should be cherry-picked into 18.5 as well.